### PR TITLE
demo: securing server-side pages

### DIFF
--- a/src/pages/demo/page-secured-client-side.tsx
+++ b/src/pages/demo/page-secured-client-side.tsx
@@ -1,20 +1,10 @@
-import {GetStaticPropsContext, GetStaticPropsResult} from "next";
-
-interface PropsData {
-  greeting: string,
-}
-
-// Next.js will call this function at build-time
-export async function getStaticProps(context: GetStaticPropsContext): Promise<GetStaticPropsResult<PropsData>> {
-  const data: PropsData = {
-    greeting: "Hello",
-  }
-
+// Static generation
+export async function getStaticProps() {
   return {
-    props: data,
+    props: {},
   };
 }
 
-export default function Page({greeting}: {greeting: string}) {
-  return <div>{greeting}! This page is <strong>secured</strong></div>;
+export default function Page() {
+  return <div>This client-side rendered page is <strong>secured</strong></div>;
 }

--- a/src/pages/demo/page-secured-server-side.tsx
+++ b/src/pages/demo/page-secured-server-side.tsx
@@ -1,0 +1,33 @@
+import {GetServerSidePropsContext} from "next";
+import {getServerSession} from "next-auth/next";
+import {useSession} from "next-auth/react";
+import {authOptions} from "../api/auth/[...nextauth]";
+
+
+// Server-side rendered (called on every request)
+export async function getServerSideProps({
+  req,
+  res
+}: GetServerSidePropsContext) {
+  return {
+    props: {
+      session: await getServerSession(
+          req,
+          res,
+          authOptions
+      ),
+    },
+  };
+}
+
+export default function Page() {
+  const {data: session} = useSession();
+
+//  if (typeof window === "undefined") return null;
+
+  if (session) {
+    return <div>This server-side rendered page is <strong>secured</strong></div>;
+  }
+
+  return <p>Access Denied</p>;
+}

--- a/src/pages/demo/page-unsecured-client-side.tsx
+++ b/src/pages/demo/page-unsecured-client-side.tsx
@@ -1,20 +1,10 @@
-import {GetStaticPropsContext, GetStaticPropsResult} from "next";
-
-interface PropsData {
-  greeting: string,
-}
-
-// Next.js will call this function at build-time
-export async function getStaticProps(context: GetStaticPropsContext): Promise<GetStaticPropsResult<PropsData>> {
-  const data: PropsData = {
-    greeting: "Hello",
-  }
-
+// Static generation
+export async function getStaticProps() {
   return {
-    props: data,
+    props: {},
   };
 }
 
 export default function Page({greeting}: {greeting: string}) {
-  return <div>{greeting}! This page is <strong>unsecured</strong></div>;
+  return <div>This client-side rendered page is intentionally <strong>unsecured</strong></div>;
 }


### PR DESCRIPTION
If you haven't done so already:

1. Generate a secret:

```bash
openssl rand -base64 32
```

Or [have one generated](https://cloud.google.com/network-connectivity/docs/vpn/how-to/generating-pre-shared-key#generated_for_you) for you.

2. Add it to `.env.local`:

```bash
NEXTAUTH_SECRET={SECRET}
```

3. Start dev server: `npm run dev`

4. Try sign in and sign out on the home page, then navigate to localhost:3000/demo/page-secured-server-side).