### PR TITLE
demo: ssg and ssr cached pages

### DIFF
--- a/src/pages/demo/ssg-cache.tsx
+++ b/src/pages/demo/ssg-cache.tsx
@@ -1,0 +1,21 @@
+import {GetStaticPropsContext, GetStaticPropsResult} from "next";
+
+interface PropsData {
+  greeting: string,
+}
+
+// Next.js will call this function at build-time
+export async function getStaticProps(context: GetStaticPropsContext): Promise<GetStaticPropsResult<PropsData>> {
+  const data: PropsData = {
+    greeting: "Hello",
+  }
+
+  return {
+    props: data,
+  };
+}
+
+export default function Page({greeting}: {greeting: string}) {
+  return <div>{greeting}! This page was <strong>statically generated</strong> and is
+    cacheable</div>;
+}

--- a/src/pages/demo/ssr-cache.tsx
+++ b/src/pages/demo/ssr-cache.tsx
@@ -1,0 +1,28 @@
+import {GetServerSidePropsContext, GetServerSidePropsResult} from "next";
+
+interface PropsData {
+  greeting: string,
+}
+
+// Next.js will call this function for every request
+// (if cache TTL has expired)
+export async function getServerSideProps({res}: GetServerSidePropsContext): Promise<GetServerSidePropsResult<PropsData>> {
+  // Must explicitly set Cache-Control for SSR pages.
+  res!.setHeader(
+      'Cache-Control',
+      'public, s-maxage=10, stale-while-revalidate'
+  );
+
+  const data: PropsData = {
+    greeting: "Hello",
+  }
+
+  return {
+    props: data,
+  };
+}
+
+export default function Page({greeting}: {greeting: string}) {
+  return <div>{greeting}! This page was dynamically <strong>server-side
+    rendered</strong> and is cacheable.</div>;
+}


### PR DESCRIPTION
1. Cache-Control headers are overwritten by the dev server, so do a production build and run for production:

```bash
npm run build
npm start
```

2. Test the following pages with `curl -v`

* localhost:3000/demo/ssg-cache
* localhost:3000/demo/ssr-cache

Verify `Cache-Control` header is set as expected (basically ` s-maxage=` to some number of seconds)