### PR TITLE
fix: tile

### DIFF
--- a/src/components/tile.tsx
+++ b/src/components/tile.tsx
@@ -17,7 +17,7 @@ export default function Component({ x, y }: GridPosition) {
   } = useGetUserQuery();
 
   const [addCompletedMission] = useAddCompletedMissionMutation()
-  
+
   const dispatch = useAppDispatch()
 
   const { playerPosition, mission, inventory, allItemsCollected, isSavingMission } = useAppSelector((state: RootState) => state.game)
@@ -44,7 +44,13 @@ export default function Component({ x, y }: GridPosition) {
 
   if (isLoading) {
     return <div>Loading...</div>
-  } else if (isSuccess) {
+  }
+
+  if (isError) {
+    return <div>{error.toString()}</div>
+  }
+
+  if (isSuccess) {
     return (
       <section className={styles.tile}>
         {playerIsOnTile && 'X'}
@@ -68,7 +74,8 @@ export default function Component({ x, y }: GridPosition) {
         )}
       </section>
     )
-  } else if (isError) {
-    return <div>{error.toString()}</div>
   }
+
+  // Better fall through logic, but can't return 'Element | undefined'
+  return <></>
 }


### PR DESCRIPTION
Tile can't return 'Element | undefined'.

Fixes for production / docker build:

```
$ npm run build
. . .
#16 0.800 info  - Linting and checking validity of types...
#16 5.102 Failed to compile.
#16 5.102 
#16 5.102 ./src/pages/index.tsx:28:14
#16 5.102 Type error: 'Footer' cannot be used as a JSX component.
#16 5.102   Its return type 'Element | undefined' is not a valid JSX element.
#16 5.102     Type 'undefined' is not assignable to type 'Element | null'.
#16 5.102 
#16 5.102   26 |             <GameControls />
#16 5.102   27 |             <Inventory />
#16 5.102 > 28 |             <Footer />
#16 5.102      |              ^
#16 5.102   29 |           </>
#16 5.102   30 |         )}
#16 5.102   31 |       </main>
```