### PR TITLE
chore: add end-to-end tests using playwright

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,29 @@
+name: End-to-end Tests
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+    - name: Install dependencies
+      run: npm ci
+    - name: Setup auth cache folder
+      run: mkdir -p playwright/.auth
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    - name: Run Playwright tests
+      run: npx playwright test
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+/test-results/
+/playwright-report/
+/playwright/.cache/
+/playwright/.auth/

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@jest/globals": "^29.5.0",
+        "@playwright/test": "^1.31.2",
         "@types/jest": "^29.4.0",
         "@types/node": "18.14.2",
         "@types/react": "18.0.28",
@@ -1582,6 +1583,25 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.2.tgz",
+      "integrity": "sha512-BYVutxDI4JeZKV1+ups6dt5WiqKhjBtIYowyZIJ3kBDmJgsuPKsqqKNIMFbUePLSCmp2cZu+BDL427RcNKTRYw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "playwright-core": "1.31.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -6775,6 +6795,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.31.2.tgz",
+      "integrity": "sha512-a1dFgCNQw4vCsG7bnojZjDnPewZcw7tZUNFN0ZkcLYKj+mPmXvg4MpaaKZ5SgqPsOmqIf2YsVRkgqiRDxD+fDQ==",
+      "dev": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test:e2e": "playwright test",
     "test": "jest --verbose --detectOpenHandles",
     "test:watch": "jest --verbose --detectOpenHandles --watch"
   },
@@ -23,6 +24,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
+    "@playwright/test": "^1.31.2",
     "@types/jest": "^29.4.0",
     "@types/node": "18.14.2",
     "@types/react": "18.0.28",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,99 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Maximum time one test can run for. */
+  timeout: 30 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5 * 1000
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    // Setup Auth
+    { name: 'setup', testMatch: /.*\.setup\.ts/ },
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/user.json',
+      },
+      testMatch: /tests.*.ts/,
+      dependencies: ['setup'],
+    },
+
+    /*
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+    */
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { channel: 'chrome' },
+    // },
+  ],
+
+  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
+  // outputDir: 'test-results/',
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+  },
+});

--- a/src/components/tile.tsx
+++ b/src/components/tile.tsx
@@ -75,7 +75,7 @@ export default function Component({ x, y }: GridPosition) {
 
           
             {playerIsOnTile && session?.user ? (
-              <UserCircleIcon className="block h-8 md:h-12 lg:h-20" aria-hidden="true" />
+              <UserCircleIcon className="block h-8 md:h-12 lg:h-20" data-testid="usericon" aria-hidden="true" />
             ) : <div />}
             {tileItem ? (
               <Image

--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -1,0 +1,14 @@
+// auth.setup.ts
+import { test as setup } from '@playwright/test';
+
+const authFile = 'playwright/.auth/user.json';
+
+setup('authenticate', async ({ page }) => {
+  // Perform authentication steps. Replace these actions with your own.
+  await page.goto('http://localhost:3000/api/auth/signin?callbackUrl=http%3A%2F%2Flocalhost%3A3000%2F');
+  const emailInput = await page.getByRole('textbox', { name: /Username/ })
+  await emailInput.fill('CI User');
+  const signInButton = await page.getByRole('button', { type: 'submit' })
+  await signInButton.click();
+  await page.context().storageState({ path: authFile });
+});

--- a/tests/play.spec.ts
+++ b/tests/play.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test('basic playthrough', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  // Expected title
+  await expect(page).toHaveTitle(/Developer Journey/);
+
+  // Displays link to Home tab
+  const homeLink = await page.getByRole('link', { name: 'Home' })
+  await expect(homeLink).toBeVisible();
+
+  // Should show up Player Username
+  const playerName = page.getByText('CI User').nth(1);
+  expect(playerName).toBeVisible();
+
+  // Moves the player to the first tile
+  const upBtn = await page.getByRole('button', { name: 'Move player up' });
+  await upBtn.click();
+  await upBtn.click();
+
+  // Validates that the user is now positioned on first tile
+  const firstTile = await page.locator('.bg-slate-200').first()
+  const player = await firstTile.getByTestId('usericon');
+  await expect(player).toBeVisible();
+});

--- a/tests/playthrough.ts
+++ b/tests/playthrough.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test('has title', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  // Expected title
+  await expect(page).toHaveTitle(/Developer Journey/);
+
+  // Displays link to Home tab
+  const homeLink = await page.getByRole('link', { name: 'Home' })
+  await expect(homeLink).toBeVisible();
+
+  // Should show up Player Username
+  const playerName = page.getByText('CI User').nth(1);
+  expect(playerName).toBeVisible();
+
+  // Moves the player to the first tile
+  const upBtn = await page.getByRole('button', { name: 'Move player up' });
+  await upBtn.click();
+  await upBtn.click();
+
+  // Validates that the user is now positioned on first tile
+  const firstTile = await page.locator('.bg-slate-200').first()
+  const player = await firstTile.getByTestId('usericon');
+  await expect(player).toBeVisible();
+});


### PR DESCRIPTION
This changeset adds a base playwright boilerplate for end-to-end tests along with a small test that validates that basic render and movement is working along with auth setup steps.

Run tests with:

    npm run test:e2e