### PR TITLE
feat: simplify auth using credentials instead of oauth provider

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -1,28 +1,32 @@
-import NextAuth, { AuthOptions } from 'next-auth';
+import NextAuth, {AuthOptions} from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
+
 
 export const authOptions: AuthOptions = {
   providers: [
     CredentialsProvider({
       credentials: {
-        username: { label: "Username", type: "text", placeholder: "username" },
-        email: { label: "Email", type: "text", placeholder: "email" },
+        username: {label: "Username", type: "text", placeholder: "username"},
+        email: {label: "Email", type: "text", placeholder: "email"},
+        // password: {label: "Password", type: "password"}
       },
       async authorize(credentials) {
         if (!credentials) {
-          // Display an  error will be displayed advising the user to check their details.
+          // Display an  error will be displayed advising the user to check
+          // their details.
           return null;
         }
 
         const username = credentials.username;
         const email = credentials.email;
-        const user = {id: "1", name: username, email: email}
+        const user = {id: "1", name: username, email: email};
 
         if (user) {
-          return user
+          return user;
         } else {
-          // Display an  error will be displayed advising the user to check their details.
-          return null
+          // Display an  error will be displayed advising the user to check
+          // their details.
+          return null;
           // Or reject this callback with an Error to send the user to the error
           // page with the error message as a query parameter
         }


### PR DESCRIPTION
Dead simple credentials provider for now, dispensing with an oauth provider. We really only need username, but right now the app expects email. This can be further simplified.