### PR TITLE
chore: use environment instead of keyfile

### DIFF
--- a/src/lib/__test__/database.test.ts
+++ b/src/lib/__test__/database.test.ts
@@ -3,7 +3,6 @@ import {Database} from "../database";
 
 const directDatabaseConnectionForTestReset = new Firestore({
   projectId: "birds-of-paradise",
-  // keyFilename: '/path/to/keyfile.json',
 });
 
 describe("database tests", () => {

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -7,13 +7,12 @@ export class Database {
   constructor() {
     this.db = new Firestore({
       projectId: "birds-of-paradise",
-      // keyFilename: '/path/to/keyfile.json',
     });
   }
 
   async setUser({email, completedMissions}: {email: string, completedMissions?: string[] }): Promise<any> {
     const userDoc = this.db.collection('users').doc(email);
-    
+
     return userDoc.set({
       email,
       completedMissions: completedMissions || [],
@@ -32,7 +31,7 @@ export class Database {
     const { completedMissions } = await this.getUser({email});
     const updatedMissions = [ ...completedMissions, missionId ]
 
-    
+
     return this.setUser({
       email,
       completedMissions: updatedMissions,


### PR DESCRIPTION
Remove comments to make it explicit that the app will use the environment, not a keyfile for the database connection.

We use the `FIRESTORE_EMULATOR_HOST` environment variable for local development and intend to use `GOOGLE_APPLICATION_CREDENTIALS`  for the deployed service for now.

