### PR TITLE
chore: minor corrections to infra files

### DIFF
--- a/build/app-build.cloudbuild.yaml
+++ b/build/app-build.cloudbuild.yaml
@@ -21,7 +21,6 @@ steps:
       - '${_AR_REPO}:${_IMAGE_TAG}'
       - '.'
 substitutions:
-  _REGION: us-west1
   _IMAGE_TAG: $SHORT_SHA
 
 # Store in Artifact Registry

--- a/infra/environments/prod/backend.tf
+++ b/infra/environments/prod/backend.tf
@@ -1,6 +1,7 @@
-# terraform {
-#   backend "gcs" {
-#     bucket = ""
-#     prefix = "value"
-#   }
-# }
+terraform {
+  backend "gcs" {
+    bucket                      = "birds-of-paradise-tf-state"
+    prefix                      = "build-cicd-state"
+    impersonate_service_account = "terraformer@birds-of-paradise.iam.gserviceaccount.com"
+  }
+}

--- a/infra/environments/prod/main.tf
+++ b/infra/environments/prod/main.tf
@@ -3,5 +3,4 @@ module "cloud_build_cicd" {
   project_id            = var.project_id
   run_service_name      = var.run_service_name
   github_repository_url = var.github_repository_url
-  run_service_account   = var.run_service_account
 }


### PR DESCRIPTION
This PR:
- removes unused `_REGION` substitution in `app-build.cloudbuild.yaml`
- removes the unneeded `run_service_account` parameter from prod root terraform module
- adds remote bucket backend to prod terraform root module