### PR TITLE
feat: allow emulator without firebase project id

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,11 @@ You can start editing pages. The browser auto-updates when you save changes.
 
 ### If you want to run the Firestore Emulator locally
 
-Choose the port you want to use for the [Firestore Emulator], for example `9999`,
-and export the `FIRESTORE_EMULATOR_HOST` environment variable:
+Choose the port you want to use for the [Firestore Emulator], for example `9999`.
+
+> Note: If you choose a port that is not `9999` for this demo, you will need to update the `host` property in `database.ts` to match your selected port.
+
+Export the `FIRESTORE_EMULATOR_HOST` environment variable:
 
 ```bash
 export FIRESTORE_EMULATOR_HOST="localhost:9999"
@@ -72,7 +75,7 @@ export FIRESTORE_EMULATOR_HOST="localhost:9999"
 Start the emulator:
 
 ```bash
-gcloud emulators firestore start --host-port="$FIRESTORE_EMULATOR_HOST"
+gcloud emulators firestore start --host-port="$FIRESTORE_EMULATOR_HOST" --project=demo-test
 ```
 
 > When the exported `FIRESTORE_EMULATOR_HOST` environment variable is set, the

--- a/src/components/tile-board.tsx
+++ b/src/components/tile-board.tsx
@@ -40,10 +40,10 @@ export default function Component() {
             Uh oh...
           </p>
           <p>
-            This typically doesn't take this long.
+            This typically does not take this long.
           </p>
           <p>
-            We'll wait two more seconds and then show you an error message.
+            We will wait two more seconds and then show you an error message.
           </p>
         </div>
       </section>

--- a/src/components/tile-board.tsx
+++ b/src/components/tile-board.tsx
@@ -1,9 +1,119 @@
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { useGetUserQuery } from "src/redux/apiSlice";
 import Tile from "./tile";
 
 export default function Component() {
 
-  return (
+  const {
+    isLoading,
+    isError,
+    error
+  } = useGetUserQuery();
 
+  const [showUhOh, setShowUhOh] = useState<Boolean>(false);
+  const [timeExpired, setTimeExpired] = useState(false);
+
+  useEffect(
+    () => {
+      if (isLoading) {
+        let timer = setTimeout(() => setTimeExpired(true), 4000);
+        return () => {
+          clearTimeout(timer);
+        };
+      }
+    },
+    [isLoading]
+  );
+
+
+  if (isLoading && !timeExpired) {
+    // a spinner
+    return (
+      <section onMouseEnter={() => setShowUhOh(true)} className="text-slate-300 bg-slate-800 rounded-l-xl my-4 col-span-3 space-y-4 p-4">
+        <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+        </svg>
+        <div className={`space-y-4 transition-all ease-in-out delay-1000 duration-1000 ${showUhOh ? 'opacity-100' : 'opacity-0'}`}>
+          <p>
+            Uh oh...
+          </p>
+          <p>
+            This typically doesn't take this long.
+          </p>
+          <p>
+            We'll wait two more seconds and then show you an error message.
+          </p>
+        </div>
+      </section>
+    )
+  }
+
+  if (isError || (isLoading && timeExpired)) {
+    return (
+      <section className="bg-slate-200 rounded-l-xl my-4 col-span-3 space-y-4 p-4">
+        <h2 className="text-2xl text-red-900">
+          There was an error retrieving the user data.
+        </h2>
+        <p>
+          If you are the application developer, the most common cause of failing to
+          retrieve user data is not properly connecting to your Firestore database.
+        </p>
+        <h3 className="text-3xl">
+          Developing Locally?
+        </h3>
+        <p>
+          Make sure you have followed the steps to
+          {' '}
+          <Link
+            href="https://github.com/GoogleCloudPlatform/developer-journey-app#if-you-want-to-run-the-firestore-emulator-locally"
+            className='underline'
+            target='_blank'
+          >
+            run the Firestore Emulator Locally
+          </Link>
+          .
+        </p>
+        <h3 className="text-3xl">
+          Deploying to Cloud Run?
+        </h3>
+        <p>
+          Make sure you have created your Firestore database.
+          This should be done automatically, so if you are continuing to experience
+          this issue, please let us know through a
+          {' '}
+          <Link
+            href="https://github.com/GoogleCloudPlatform/developer-journey-app/issues"
+            className='underline'
+            target='_blank'
+          >
+            GitHub Issue
+          </Link>
+          .
+        </p>
+        {error ? (
+          <>
+            <h3 className="text-3xl">
+              Here is the full error message:
+            </h3>
+            <pre className="whitespace-pre-wrap">
+              {JSON.stringify(error, null, 2)}
+            </pre>
+          </>
+        ) : (
+          <>
+            <p>
+              If you wait for the request to time out.
+              We will display the full error message when it returns.
+            </p>
+          </>
+        )}
+      </section>
+    )
+  }
+
+  return (
     <section className="bg-slate-800 rounded-l-xl my-4 col-span-3 space-y-4">
       <section className="grid grid-cols-3 gap-3 col-span-3 p-4">
         <Tile x={0} y={2} />

--- a/src/lib/__test__/database.test.ts
+++ b/src/lib/__test__/database.test.ts
@@ -9,6 +9,7 @@ describe("database tests", () => {
   let fs: Database;
 
   beforeAll(async () => {
+    process.env = {...process.env, NODE_ENV: 'development'}
     await directDatabaseConnectionForTestReset.collection('users').doc('Bob').delete()
     fs = new Database();
   })

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -1,32 +1,41 @@
-import {Firestore} from "@google-cloud/firestore";
+import { Firestore } from "@google-cloud/firestore";
 import { User } from "src/models/User";
 
 export class Database {
   private db: Firestore;
 
   constructor() {
-    const projectId = process.env.PROJECT_ID;
-    if (!projectId) {
-      const errMessage = "PROJECT_ID environment variable must be defined.";
-      console.error(errMessage);
-      throw new Error(errMessage);
+    if (process.env.NODE_ENV === 'development') {
+      // use the firestore emulator
+      this.db = new Firestore({
+        host: "localhost:9999",
+        projectId: "demo-test",
+        ssl: false,
+      });
+    } else {
+      // use the PROJECT_ID environment variable
+      const projectId = process.env.PROJECT_ID;
+      if (!projectId) {
+        const errMessage = "PROJECT_ID environment variable must be defined.";
+        console.error(errMessage);
+        throw new Error(errMessage);
+      }
+      this.db = new Firestore({
+        projectId: projectId,
+      });
     }
-
-    this.db = new Firestore({
-      projectId: projectId,
-    });
   }
 
-  async setUser({username, completedMissions}: {username: string, completedMissions?: string[] }): Promise<any> {
+  async setUser({ username, completedMissions }: { username: string, completedMissions?: string[] }): Promise<any> {
     const userDoc = this.db.collection('users').doc(username);
 
     return userDoc.set({
       username,
       completedMissions: completedMissions || [],
-    }, {merge: true});
+    }, { merge: true });
   }
 
-  async getUser({username}: {username: string}): Promise<User> {
+  async getUser({ username }: { username: string }): Promise<User> {
     const userDoc = this.db.collection('users').doc(username);
     const snapshot = await userDoc.get();
     const completedMissions = snapshot.data()?.completedMissions || [];
@@ -34,9 +43,9 @@ export class Database {
     return { username, completedMissions }
   }
 
-  async addCompletedMission({username, missionId}: {username: string, missionId: string}): Promise<any> {
-    const { completedMissions } = await this.getUser({username});
-    const updatedMissions = [ ...completedMissions, missionId ]
+  async addCompletedMission({ username, missionId }: { username: string, missionId: string }): Promise<any> {
+    const { completedMissions } = await this.getUser({ username });
+    const updatedMissions = [...completedMissions, missionId]
 
 
     return this.setUser({


### PR DESCRIPTION
The project was failing to spin up locally after we removed the project id. Since developers pulling this down for the first time to run locally might not have a project id, this will enable local development.