### PR TITLE
fix: ensure valid length for cloud build service account

### DIFF
--- a/terraform/modules/cicd/main.tf
+++ b/terraform/modules/cicd/main.tf
@@ -66,7 +66,7 @@ resource "google_pubsub_topic" "gcr" {
 # Cloud Build resources (triggers, service account, and IAM bindings)
 resource "google_service_account" "cloud_build" {
   project      = var.project_id
-  account_id   = "${var.run_service_name}-builder"
+  account_id   = "${substr(var.run_service_name, 0, 22)}-builder"
   display_name = "Service Account for Cloud Build deployment to Cloud Run."
 }
 


### PR DESCRIPTION
Terraform plan and apply fail due to not matching the regex for a valid service account name (too long).

<img width="941" alt="image" src="https://github.com/GoogleCloudPlatform/developer-journey-app/assets/159738/a7f022bb-2c58-495d-a272-3f218a02384a">

This PR applies the `substr` function to ensure the length isn't exceeded. I'm not a TF expert, so if this isn't an ideal fix, or if there are other changes that need to be coordinated, please guide me with a suggestion or feel free to close this PR and submit a separate one (and add me as a reviewer). Thanks!
