### PR TITLE
fix: adjust length of deployment name throughout cicd 

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 export {default} from "next-auth/middleware"
 
 export const config = { matcher: ["/demo/page-secured-client-side"] }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 export {default} from "next-auth/middleware"
 
 export const config = { matcher: ["/demo/page-secured-client-side"] }

--- a/terraform/environments/main/main.tf
+++ b/terraform/environments/main/main.tf
@@ -17,4 +17,5 @@ module "cicd_pipeline" {
   project_id            = var.project_id
   run_service_name      = var.run_service_name
   github_repository_url = var.github_repository_url
+  deployment_name = "dynamic-web-app-with-javascript"
 }

--- a/terraform/environments/main/terraform.tfvars.example
+++ b/terraform/environments/main/terraform.tfvars.example
@@ -1,3 +1,4 @@
 project_id            = # VALUE FOR PROJECT ID
 run_service_name      = # THE NAME OF YOUR RUN SERVICE
 github_repository_url = # THE URL OF YOUR GITHUB REPOSITORY 
+deployment_name = # NAME OF THE JUMP START SOLUTION DEPLOYMENT

--- a/terraform/modules/cicd/main.tf
+++ b/terraform/modules/cicd/main.tf
@@ -201,7 +201,7 @@ resource "google_clouddeploy_delivery_pipeline" "default" {
 
 resource "google_service_account" "cloud_deploy" {
   project      = var.project_id
-  account_id   = "${var.deployment_name}-cloud-deploy"
+  account_id   = "${substr(var.deployment_name, 0, 17)}-cloud-deploy" 
   display_name = "Service Account for Cloud Deploy deployment to Cloud Run."
 }
 


### PR DESCRIPTION
## Description
This PR
- adds the Jumpstart solution deployment name to the `terraform.tfvars.example` file. This was previously assumed to be `developer-journey` by default
- ensures the cloud deploy service account is an appropriate length



**Note:** Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] Added steps to reproduce the changes in this pull request
- [ ] Added relevant testing in this pull request
- [X] Please **merge** this PR for me once it is approved.

