### PR TITLE
fix: remove use of deployment_name variable from cicd terraform

### DIFF
--- a/terraform/environments/main/main.tf
+++ b/terraform/environments/main/main.tf
@@ -17,4 +17,5 @@ module "cicd_pipeline" {
   project_id            = var.project_id
   run_service_name      = var.run_service_name
   github_repository_url = var.github_repository_url
+  lb_ip_address         = var.lb_ip_address
 }

--- a/terraform/environments/main/terraform.tfvars.example
+++ b/terraform/environments/main/terraform.tfvars.example
@@ -1,3 +1,4 @@
 project_id            = # VALUE FOR PROJECT ID
 run_service_name      = # THE NAME OF YOUR RUN SERVICE
 github_repository_url = # THE URL OF YOUR GITHUB REPOSITORY 
+lb_ip_address         = # THE IP ADDRESS OF YOUR DEPLOYMENT

--- a/terraform/environments/main/variables.tf
+++ b/terraform/environments/main/variables.tf
@@ -27,3 +27,8 @@ variable "github_repository_url" {
   type        = string
   description = "URL of connected GitHub repository (https://github.com/repo_owner/repo_name)"
 }
+
+variable "lb_ip_address" {
+  type        = string
+  description = "The IP address of your developer journey deployment"
+}

--- a/terraform/modules/cicd/cloudbuild/app-prod.yaml.tftpl
+++ b/terraform/modules/cicd/cloudbuild/app-prod.yaml.tftpl
@@ -1,7 +1,7 @@
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
-  name: ${deployment_name}
+  name: ${run_service_name}
 spec:
   template:
     spec:
@@ -16,5 +16,5 @@ spec:
           valueFrom:
             secretKeyRef:
               key: latest
-              name: ${deployment_name}-nextauth-secret
+              name: ${run_service_name}-nextauth-secret
       serviceAccountName: ${run_service_account}

--- a/terraform/modules/cicd/main.tf
+++ b/terraform/modules/cicd/main.tf
@@ -21,7 +21,7 @@ locals {
   app_build_config       = templatefile("${path.module}/cloudbuild/app-build.cloudbuild.yaml.tftpl", {})
   skaffold_config        = templatefile("${path.module}/cloudbuild/skaffold.yaml.tftpl", { name = "dev-journey" })
   run_config = templatefile("${path.module}/cloudbuild/app-prod.yaml.tftpl",
-    { deployment_name     = "dev-journey"
+    { run_service_name    = var.run_service_name
       lb_ip_address       = var.lb_ip_address
       project_id          = var.project_id
       run_service_account = data.google_service_account.cloud_run.email

--- a/terraform/modules/cicd/variables.tf
+++ b/terraform/modules/cicd/variables.tf
@@ -23,10 +23,9 @@ variable "region" {
   default     = "us-central1"
 }
 
-variable "deployment_name" {
+variable "lb_ip_address" {
   type        = string
-  description = "Identifier for the deployment. Used in some resource names."
-  default     = "dev-journey"
+  description = "The IP address of your developer journey deployment"
 }
 
 variable "enable_apis" {


### PR DESCRIPTION
## Description
Fixes #90 

This PR will:
- Update the required variables in the terraform.tfvars.examples to include the load balancer IP address
- Remove references to the `deployment_name` variable, which by default was the string 'dev-journey'
- Replaces references to the `deployment_name` variable with string `dev-journey`

To verify:
1. deploy the Jump Start solution to a new project
1. Walk through steps in `terraform/README.md`
1. Commit a change to any file in the `src/` directory to trigger the pipeline
1. Verify it is able to complete
 
**Note:** Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] Added steps to reproduce the changes in this pull request
- [ ] Added relevant testing in this pull request
- [X] Please **merge** this PR for me once it is approved.

