### PR TITLE
fix: remove use of deployment_name variable from cicd terraform

### DIFF
--- a/terraform/modules/cicd/cloudbuild/app-prod.yaml.tftpl
+++ b/terraform/modules/cicd/cloudbuild/app-prod.yaml.tftpl
@@ -1,7 +1,7 @@
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
-  name: ${deployment_name}
+  name: ${run_service_name}
 spec:
   template:
     spec:
@@ -16,5 +16,5 @@ spec:
           valueFrom:
             secretKeyRef:
               key: latest
-              name: ${deployment_name}-nextauth-secret
+              name: ${run_service_name}-nextauth-secret
       serviceAccountName: ${run_service_account}

--- a/terraform/modules/cicd/main.tf
+++ b/terraform/modules/cicd/main.tf
@@ -21,7 +21,7 @@ locals {
   app_build_config       = templatefile("${path.module}/cloudbuild/app-build.cloudbuild.yaml.tftpl", {})
   skaffold_config        = templatefile("${path.module}/cloudbuild/skaffold.yaml.tftpl", { name = var.run_service_name })
   run_config = templatefile("${path.module}/cloudbuild/app-prod.yaml.tftpl",
-    { run_service_name     = var.run_service_name
+    { run_service_name    = var.run_service_name
       lb_ip_address       = data.google_compute_global_address.default.address
       project_id          = var.project_id
       run_service_account = data.google_service_account.cloud_run.email

--- a/terraform/modules/cicd/main.tf
+++ b/terraform/modules/cicd/main.tf
@@ -49,7 +49,7 @@ data "google_compute_global_address" "default" {
 resource "google_artifact_registry_repository" "default" {
   project       = var.project_id
   location      = var.region
-  repository_id = "${var.run_service_name}-repo"
+  repository_id = "dev-journey-repo"
   description   = "Dev journey artifact registry repo."
   format        = "DOCKER"
   labels        = var.labels
@@ -102,7 +102,7 @@ resource "google_project_iam_member" "builder_run_developer" {
 
 resource "google_cloudbuild_trigger" "app_new_build" {
   project         = var.project_id
-  name            = "${var.run_service_name}-app-build"
+  name            = "dev-journey-app-build"
   description     = "Initiates new build of ${var.run_service_name}. Triggers by changes to app on main branch of source repo."
   service_account = google_service_account.cloud_build.id
   included_files = [
@@ -139,7 +139,7 @@ resource "google_cloudbuild_trigger" "app_new_build" {
 
 resource "google_cloudbuild_trigger" "app_new_release" {
   project         = var.project_id
-  name            = "${var.run_service_name}-new-release"
+  name            = "dev-journey-new-release"
   description     = "Triggers on any new build pushed to Artifact Registry. Creates a new release in Cloud Deploy."
   service_account = google_service_account.cloud_build.id
   pubsub_config {
@@ -185,7 +185,7 @@ resource "google_cloudbuild_trigger" "app_new_release" {
 resource "google_clouddeploy_delivery_pipeline" "default" {
   project     = var.project_id
   location    = var.region
-  name        = "${var.run_service_name}-delivery"
+  name        = "dev-journey-delivery"
   description = "Basic delivery pipeline for ${var.run_service_name} app."
   labels      = var.labels
   serial_pipeline {
@@ -201,7 +201,7 @@ resource "google_clouddeploy_delivery_pipeline" "default" {
 
 resource "google_service_account" "cloud_deploy" {
   project      = var.project_id
-  account_id   = "${var.run_service_name}-cloud-deploy"
+  account_id   = "${substr(var.run_service_name, 0, 21)}-deployer"
   display_name = "Service Account for Cloud Deploy deployment to Cloud Run."
 }
 
@@ -229,7 +229,7 @@ resource "google_clouddeploy_target" "prod" {
   project     = var.project_id
   provider    = google
   location    = var.region
-  name        = "${var.run_service_name}-prod-target"
+  name        = "dev-journey-prod-target"
   description = "Prod target for ${var.run_service_name} app."
 
   execution_configs {

--- a/terraform/modules/cicd/variables.tf
+++ b/terraform/modules/cicd/variables.tf
@@ -23,12 +23,6 @@ variable "region" {
   default     = "us-central1"
 }
 
-variable "deployment_name" {
-  type        = string
-  description = "Identifier for the deployment. Used in some resource names."
-  default     = "dev-journey"
-}
-
 variable "enable_apis" {
   type        = bool
   description = "Whether or not to enable underlying apis in this solution."


### PR DESCRIPTION
## Description
Fixes #90 

This PR will:
- Remove uses of the `deployment_name` variable in cicd terraform
- Replaces references to the `deployment_name` variable with string `dev-journey` or `run_service_name` variable
- 
To verify:
1. deploy the Jump Start solution to a new project
1. Walk through steps in `terraform/README.md`
1. Commit a change to any file in the `src/` directory to trigger the pipeline
1. Verify it is able to complete
 
**Note:** Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] Added steps to reproduce the changes in this pull request
- [ ] Added relevant testing in this pull request
- [X] Please **merge** this PR for me once it is approved.

