### PR TITLE
feat: health check - can connect to firestore

### DIFF
--- a/src/pages/api/fscheck.ts
+++ b/src/pages/api/fscheck.ts
@@ -15,25 +15,14 @@
  */
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { Database } from "../../lib/database";
-import { User } from 'src/models/User';
-import { getSession } from 'next-auth/react';
+
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<User>
+  res: NextApiResponse,
 ) {
   const fs = new Database();
-  const session = await getSession({ req });
-  const username = session?.user?.name || '';
-  if (!username) {
-    return res.status(200).send({ username, completedMissions: [] });
-  }
-
-  if (req.method === 'POST') {
-    const missionId = req.body.id;
-    await fs.addCompletedMission({ username, missionId })
-  }
-
-  const user = await fs.getUser({ username });
-  res.status(200).json(user)
+  let isConnected = await fs.isConnected();
+  let statusCode = isConnected ? 200 : 503;
+  res.status(statusCode).end();
 }


### PR DESCRIPTION
Adds a health check GET endpoint that confirms app can connect to Firestore: `/api/fscheck`
The endpoint returns either an HTTP `200` or `503`.
