### PR TITLE
feat: add boilerplate .env for dev env setup

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,3 @@
-NEXT_AUTHURL="http://localhost"
-NEXTAUTH_SECRET="development"
 FIRESTORE_EMULATOR_HOST="localhost:9999"
+NEXTAUTH_URL="http://localhost:3000"
+NEXTAUTH_SECRET="secret"

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,3 @@
 FIRESTORE_EMULATOR_HOST="localhost:9999"
 NEXTAUTH_URL_INTERNAL="http://localhost:3000"
-NEXTAUTH_SECRET="secret"
+NEXTAUTH_SECRET=`openssl rand -hex 32`

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,3 @@
+NEXT_AUTHURL="http://localhost"
+NEXTAUTH_SECRET="development"
+FIRESTORE_EMULATOR_HOST="localhost:9999"

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,3 @@
 FIRESTORE_EMULATOR_HOST="localhost:9999"
-NEXTAUTH_URL="http://localhost:3000"
+NEXTAUTH_URL_INTERNAL="http://localhost:3000"
 NEXTAUTH_SECRET="secret"


### PR DESCRIPTION
This PR adds an `env.local.example` with environment variables and values to use for development:

`FIRESTORE_EMULATOR_HOST`
`NEXTAUTH_URL_INTERNAL`
`NEXTAUTH_SECRET`


